### PR TITLE
security: remove indexed credential material

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,9 +2,9 @@ name: Validate notebooks
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   security:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,22 @@
+name: Validate notebooks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  security:
+    name: Secret and JSON validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Scan tracked content for credential patterns
+        run: ./scripts/scan-secrets.sh
+
+      - name: Validate notebook JSON
+        run: |
+          python3 -m json.tool 01_wti_brent_spread_analysis.ipynb >/dev/null
+          python3 -m json.tool 02_oil_price_technical_analysis.ipynb >/dev/null

--- a/KAGGLE_SETUP_COMPLETE.md
+++ b/KAGGLE_SETUP_COMPLETE.md
@@ -1,146 +1,48 @@
-# Kaggle Notebooks - Setup Complete
+# Kaggle Publication Checklist
 
-## Summary
+This repository contains reference notebooks for OilPriceAPI analysis. Public
+notebook metadata and stored outputs must remain reproducible, source-timestamped,
+and free of credentials or account details.
 
-Two professional Jupyter notebooks are ready on GitHub and need to be imported to Kaggle.
+## Before Publishing
 
-**GitHub Repo**: https://github.com/OilpriceAPI/kaggle-notebooks
+1. Import the notebook from
+   [OilpriceAPI/kaggle-notebooks](https://github.com/OilpriceAPI/kaggle-notebooks).
+2. Add `OILPRICEAPI_KEY` through Kaggle Secrets. Never paste a key into a cell,
+   output, URL, commit, screenshot, issue, or notebook metadata.
+3. Enable internet access for package installation and API requests.
+4. Run every cell from a clean kernel.
+5. Confirm the notebook reports commodity code, currency, unit, source
+   timestamp, requested date range, and any data limitations.
+6. Confirm missing secret, authentication, entitlement, rate-limit, timeout,
+   empty response, and malformed response paths give a working next action.
+7. Clear mutable outputs before committing the repository copy. Public Kaggle
+   outputs must identify their execution time and must not be described as
+   current after that run.
+8. Run the repository validation commands before publishing:
 
-## Notebooks Ready
+   ```bash
+   ./scripts/scan-secrets.sh
+   python3 -m pytest -q
+   ```
 
-### 1. WTI vs Brent Spread Analysis
-**File**: `01_wti_brent_spread_analysis.ipynb`
+## Product Claims
 
-**Features**:
-- Fetches 6 months of WTI and Brent crude data
-- Calculates and visualizes price spread
-- Identifies trading opportunities
-- Professional charts and statistics
+Use the reviewed contract for offer, catalog, freshness, entitlement, and
+data-rights facts:
 
-### 2. Oil Price Technical Analysis
-**File**: `02_oil_price_technical_analysis.ipynb`
+- [Product facts](https://api.oilpriceapi.com/product-facts.json)
+- [Documentation](https://docs.oilpriceapi.com)
+- [Pricing and current access](https://www.oilpriceapi.com/pricing)
+- [Data usage policy](https://www.oilpriceapi.com/legal/data-usage)
 
-**Features**:
-- Fetches 6 months of Brent crude data
-- Technical indicators (SMA, EMA, RSI)
-- Moving average crossovers
-- Volatility analysis
+Latest available values include source timestamps. Refresh cadence varies by
+source, market hours, dataset, and plan. Do not describe notebook values as a
+live executable quote or imply guaranteed freshness.
 
-## Changes Made
+## Publication Receipt
 
-✅ **API Key Confirmed**: Email confirmed for `karl.waldman+admin@gmail.com`
-✅ **Timeout Increased**: 120 seconds (from 30s default)
-✅ **Date Range Optimized**: 180 days instead of 365 (6 months vs 1 year)
-✅ **Multiple Backlinks**: Each notebook includes 5+ links to oilpriceapi.com
-
-## Next Steps for You
-
-### 1. Import to Kaggle (5 minutes each)
-
-**Notebook 1:**
-1. Go to https://www.kaggle.com/code
-2. Click "New Notebook" → "Import Notebook"
-3. Select "GitHub" tab
-4. Enter: `OilpriceAPI/kaggle-notebooks/01_wti_brent_spread_analysis.ipynb`
-5. Click "Import"
-
-**Notebook 2:**
-1. Repeat same process
-2. Use: `OilpriceAPI/kaggle-notebooks/02_oil_price_technical_analysis.ipynb`
-
-### 2. Add API Key Secret (30 seconds each)
-
-In each notebook:
-1. Click "Add-ons" → "Secrets"
-2. Click "Add a new secret"
-3. **Label**: `OILPRICEAPI_KEY`
-4. **Value**: `3839c085460dd3a9dac1291f937f5a6d1740e8c668c766bc9f95e166af59cb11`
-5. Click "Add"
-
-### 3. Enable Internet & Run (2 minutes each)
-
-1. Click "Settings" → Enable "Internet"
-2. Click "Run All"
-3. Wait 2-3 minutes for execution
-4. Verify charts and data appear
-
-### 4. Make Public (10 seconds each)
-
-1. Click "Share" → "Make Public"
-2. This activates the DA 70 backlinks!
-
-### 5. Get URLs & Update README
-
-Once public, get the URLs (format: `https://www.kaggle.com/code/kwaldman/notebook-slug`)
-
-Then update the README:
-```bash
-cd /home/kwaldman/code/kaggle-notebooks
-# Edit README.md to add Kaggle URLs
-git add README.md
-git commit -m "Add live Kaggle notebook URLs"
-git push
-```
-
-## API Key Details
-
-**Email**: karl.waldman+admin@gmail.com
-**Confirmed**: ✅ Yes (2025-11-26)
-**API Key**: `3839c085460dd3a9dac1291f937f5a6d1740e8c668c766bc9f95e166af59cb11`
-**Rate Limit**: Unlimited (admin account)
-
-## Known Issues
-
-⚠️ **API Performance**: `/v1/prices/past_year` endpoint is slow (74+ seconds)
-- **Issue**: https://github.com/OilpriceAPI/oilpriceapi-api/issues/608
-- **Workaround**: Reduced to 180 days (6 months) in notebooks
-- **Fix Needed**: Database indexing and query optimization
-
-## Expected Results
-
-### Week 1:
-- 2 DA 70 backlinks live
-- Indexed by Google
-- 10-50 views
-
-### Month 1:
-- 100-500 views per notebook
-- 5-10 upvotes
-- 2-5 forks
-- Comments from data scientists
-
-### Month 3:
-- 500-2,000 views per notebook
-- Referenced in blog posts
-- Potential DA +1-2 points
-- Community credibility boost
-
-## Backlinks in Each Notebook
-
-1. https://oilpriceapi.com
-2. https://oilpriceapi.com/auth/signup
-3. https://docs.oilpriceapi.com
-4. https://github.com/oilpriceapi/python-sdk
-5. https://github.com/OilpriceAPI/kaggle-notebooks
-
-**Total**: 10 DA 70 backlinks (5 per notebook × 2 notebooks)
-
-## Files on GitHub
-
-```
-kaggle-notebooks/
-├── README.md
-├── 01_wti_brent_spread_analysis.ipynb
-├── 02_oil_price_technical_analysis.ipynb
-└── .gitignore
-```
-
-## Support
-
-If notebooks fail to run:
-1. Check API key is added to Secrets correctly
-2. Verify "Internet" is enabled in Settings
-3. Check execution logs for specific errors
-4. API may be slow - wait up to 3 minutes
-
-Ready to import! 🚀
+After a successful Kaggle run, record the public notebook URL, repository
+commit, package version, execution timestamp, and validation result in the
+release notes and the tracking issue. Do not record the secret, account email,
+customer identifiers, request limits, or raw account responses.

--- a/scripts/scan-secrets.sh
+++ b/scripts/scan-secrets.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root_dir"
+
+failed=0
+scan() {
+  local label="$1"
+  local pattern="$2"
+  local matches
+  matches="$(rg -l --hidden --glob '!.git/**' --glob '!scripts/scan-secrets.sh' "$pattern" . || true)"
+  if [[ -n "$matches" ]]; then
+    printf 'Potential %s found in:\n%s\n' "$label" "$matches" >&2
+    failed=1
+  fi
+}
+
+scan "64-character credential" '[A-Fa-f0-9]{64}'
+scan "OilPriceAPI token" '(oilpriceapi_|opa_)[A-Za-z0-9_-]{20,}'
+scan "assigned API credential" '(api[_ -]?key|token)[[:space:]]*[:=][[:space:]]*"?[A-Za-z0-9_-]{32,}'
+
+if [[ "$failed" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "secret scan passed"


### PR DESCRIPTION
Security prerequisite for #8.

- removes an invalid but fully exposed API key, a personal account identifier, mutable admin-limit details, and unsupported traffic/backlink forecasts from the indexed setup record
- replaces the record with a credential-safe publication checklist tied to the reviewed product facts
- adds a CI secret scan that reports filenames only and validates both notebook JSON files

Verification: the exposed value returns HTTP 401; `./scripts/scan-secrets.sh`, both `python3 -m json.tool` checks, and `git diff --check` pass.

History is not rewritten in this PR; the value is invalid, and destructive history rewriting requires a separate explicit decision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated validation for notebooks on pushes and pull requests.
  * Added secret scanning to detect potential credentials before changes are accepted.

* **Documentation**
  * Replaced the detailed setup guide with a concise Kaggle publication checklist.
  * Added guidance for validation, product claims, and recording non-sensitive publication details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->