### PR TITLE
P1: pin notebooks to source-accurate Python SDK 1.11.0

### DIFF
--- a/01_wti_brent_spread_analysis.ipynb
+++ b/01_wti_brent_spread_analysis.ipynb
@@ -10,7 +10,7 @@
     "This notebook compares API-timestamped WTI and Brent records returned by OilPriceAPI.\n",
     "It is an educational analysis, not a trading signal or investment recommendation.\n",
     "\n",
-    "- SDK: `oilpriceapi[pandas]==1.10.2`\n",
+    "- SDK: `oilpriceapi[pandas]==1.11.0`\n",
     "- Authentication: Kaggle Secrets label `OILPRICEAPI_KEY`\n",
     "- [Reviewed product facts](https://api.oilpriceapi.com/product-facts.json) (contract 2026-07-18)\n",
     "- [Current API documentation](https://docs.oilpriceapi.com/api-reference/prices/latest)\n",
@@ -36,7 +36,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q \"oilpriceapi[pandas]==1.10.2\" matplotlib seaborn"
+    "%pip install -q \"oilpriceapi[pandas]==1.11.0\" matplotlib seaborn"
    ]
   },
   {
@@ -522,7 +522,7 @@
    "isGpuEnabled": false
   },
   "oilpriceapi": {
-   "sdkVersion": "1.10.2",
+   "sdkVersion": "1.11.0",
    "contractVersion": "2026-07-18",
    "productFactsUrl": "https://api.oilpriceapi.com/product-facts.json",
    "outputsCleared": true

--- a/02_oil_price_technical_analysis.ipynb
+++ b/02_oil_price_technical_analysis.ipynb
@@ -11,7 +11,7 @@
     "OilPriceAPI. Indicators summarize the requested sample; they do not forecast prices\n",
     "or constitute a trading or investment recommendation.\n",
     "\n",
-    "- SDK: `oilpriceapi[pandas]==1.10.2`\n",
+    "- SDK: `oilpriceapi[pandas]==1.11.0`\n",
     "- Authentication: Kaggle Secrets label `OILPRICEAPI_KEY`\n",
     "- [Reviewed product facts](https://api.oilpriceapi.com/product-facts.json) (contract 2026-07-18)\n",
     "- [Current API documentation](https://docs.oilpriceapi.com/api-reference/prices/latest)\n",
@@ -37,7 +37,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%pip install -q \"oilpriceapi[pandas]==1.10.2\" matplotlib seaborn"
+    "%pip install -q \"oilpriceapi[pandas]==1.11.0\" matplotlib seaborn"
    ]
   },
   {
@@ -527,7 +527,7 @@
    "isGpuEnabled": false
   },
   "oilpriceapi": {
-   "sdkVersion": "1.10.2",
+   "sdkVersion": "1.11.0",
    "contractVersion": "2026-07-18",
    "productFactsUrl": "https://api.oilpriceapi.com/product-facts.json",
    "outputsCleared": true

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Both public Kaggle URLs currently require a republish receipt for this repositor
 
 ## Runtime Contract
 
-- Python package: `oilpriceapi[pandas]==1.10.2`
+- Python package: `oilpriceapi[pandas]==1.11.0`
 - Secret label: `OILPRICEAPI_KEY` through Kaggle Add-ons > Secrets
 - First request: `GET /v1/prices/latest?by_code=BRENT_CRUDE_USD`
 - History request: `GET /v1/prices/historical` with explicit dates and `interval=daily`
@@ -33,7 +33,7 @@ The notebooks preserve symbol, numeric value, currency, unit, source, the exact 
 ## Validate Locally
 
 ```bash
-python3 -m pip install "oilpriceapi[pandas]==1.10.2" matplotlib seaborn
+python3 -m pip install "oilpriceapi[pandas]==1.11.0" matplotlib seaborn
 python3 scripts/generate_notebooks.py
 ./scripts/scan-secrets.sh
 python3 -m unittest discover -s tests -v
@@ -46,6 +46,6 @@ The unit suite executes the exact committed notebook cells against deterministic
 
 - [Product facts](https://api.oilpriceapi.com/product-facts.json)
 - [API reference](https://docs.oilpriceapi.com/api-reference/prices/latest)
-- [Python SDK](https://pypi.org/project/oilpriceapi/1.10.2/)
+- [Python SDK](https://pypi.org/project/oilpriceapi/1.11.0/)
 - [Data usage policy](https://www.oilpriceapi.com/legal/data-usage)
 - [Service status](https://status.oilpriceapi.com)

--- a/scripts/generate_notebooks.py
+++ b/scripts/generate_notebooks.py
@@ -9,7 +9,7 @@ from typing import Any, Dict, List
 
 
 ROOT = Path(__file__).resolve().parents[1]
-SDK_VERSION = "1.10.2"
+SDK_VERSION = "1.11.0"
 CONTRACT_VERSION = "2026-07-18"
 SUPPORT_SOURCE = (ROOT / "scripts" / "notebook_support.py").read_text()
 
@@ -148,7 +148,7 @@ SPREAD_INTRO = """# WTI and Brent Spread Analysis
 This notebook compares API-timestamped WTI and Brent records returned by OilPriceAPI.
 It is an educational analysis, not a trading signal or investment recommendation.
 
-- SDK: `oilpriceapi[pandas]==1.10.2`
+- SDK: `oilpriceapi[pandas]==1.11.0`
 - Authentication: Kaggle Secrets label `OILPRICEAPI_KEY`
 - [Reviewed product facts](https://api.oilpriceapi.com/product-facts.json) (contract 2026-07-18)
 - [Current API documentation](https://docs.oilpriceapi.com/api-reference/prices/latest)
@@ -210,7 +210,7 @@ This notebook calculates descriptive indicators from Brent records returned by
 OilPriceAPI. Indicators summarize the requested sample; they do not forecast prices
 or constitute a trading or investment recommendation.
 
-- SDK: `oilpriceapi[pandas]==1.10.2`
+- SDK: `oilpriceapi[pandas]==1.11.0`
 - Authentication: Kaggle Secrets label `OILPRICEAPI_KEY`
 - [Reviewed product facts](https://api.oilpriceapi.com/product-facts.json) (contract 2026-07-18)
 - [Current API documentation](https://docs.oilpriceapi.com/api-reference/prices/latest)

--- a/tests/test_notebooks.py
+++ b/tests/test_notebooks.py
@@ -14,7 +14,7 @@ from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 NOTEBOOKS = sorted(ROOT.glob("*.ipynb"))
-SDK_VERSION = "1.10.2"
+SDK_VERSION = "1.11.0"
 
 
 def load_support():


### PR DESCRIPTION
Updates the deterministic notebook generator, both output-free notebooks, tests, and documentation to the publicly verified Python SDK 1.11.0 release.\n\nVerification:\n- Ruff passes\n- five contract tests pass, including exact notebook-cell execution\n- secret scan passes\n- Kaggle packages regenerate with public metadata\n\nThis keeps the repository artifacts current; authenticated publication to the two existing Kaggle URLs remains tracked in #8.